### PR TITLE
Modify Theme color management

### DIFF
--- a/lea_common-color_themes.adb
+++ b/lea_common-color_themes.adb
@@ -1,5 +1,134 @@
 package body LEA_Common.Color_Themes is
 
+  Selected_Theme : Color_Theme_Type := Default;
+
+  White           : constant RGB_Type := 16#FFFFFF#;
+  Black           : constant RGB_Type := 16#000000#;
+  Silver          : constant RGB_Type := 16#E0E0E0#;
+  Very_Light_Gray : constant RGB_Type := 16#F8F8F8#;
+  Light_Gray      : constant RGB_Type := 16#C0C0C0#;
+  Gray            : constant RGB_Type := 16#808080#;
+  Dark_Gray       : constant RGB_Type := 16#404040#;
+  Red             : constant RGB_Type := 16#FF0000#;
+  Dark_Red        : constant RGB_Type := 16#800000#;
+  Green           : constant RGB_Type := 16#00FF00#;
+  Dark_Green      : constant RGB_Type := 16#008000#;
+  Light_Blue      : constant RGB_Type := 16#88DDFF#;
+  Blue            : constant RGB_Type := 16#0000FF#;
+  Dark_Blue       : constant RGB_Type := 16#000080#;
+  Yellow          : constant RGB_Type := 16#FFFF00#;
+  Magenta         : constant RGB_Type := 16#FF00FF#;
+  Cyan            : constant RGB_Type := 16#00FFFF#;
+  Pink            : constant RGB_Type := 16#FFAFAF#;
+  Orange          : constant RGB_Type := 16#FFC800#;
+  Dark_Orange     : constant RGB_Type := 16#F08D24#;
+
+  package Solarized is
+    --  https://ethanschoonover.com/solarized/#the-values
+    --  https://en.wikipedia.org/wiki/Solarized
+
+    --  Base tones, dark to light:
+    base02 : constant RGB_Type := 16#073642#;
+    base01 : constant RGB_Type := 16#586e75#;
+    base00 : constant RGB_Type := 16#657b83#;
+--    base0  : constant RGB_Type := 16#839496#;
+    base1  : constant RGB_Type := 16#93a1a1#;
+    base2  : constant RGB_Type := 16#eee8d5#;
+    base3  : constant RGB_Type := 16#fdf6e3#;
+
+    --  Colours:
+    orange  : constant RGB_Type := 16#cb4b16#;
+    red     : constant RGB_Type := 16#dc322f#;
+    magenta : constant RGB_Type := 16#d33682#;
+    blue    : constant RGB_Type := 16#268bd2#;
+    cyan    : constant RGB_Type := 16#2aa198#;
+    green   : constant RGB_Type := 16#859900#;
+
+  end Solarized;
+
+  theme_color_array : constant array (Color_Theme_Type, Color_Topic) of RGB_Type :=
+    (Default =>
+       (foreground                      => 16#101010#,
+        background                      => White,
+        keyword                         => Blue,
+        number                          => Dark_Orange,
+        comment                         => Dark_Green,
+        string_literal                  => Dark_Gray,
+        character_literal               => Dark_Gray,
+        error_foreground                => Black,
+        error_background                => Pink,
+        caret                           => Black,
+        selection_foreground            => Black,
+        selection_background            => Light_Gray,
+        matched_parenthesis             => Dark_Green,
+        unmatched_parenthesis           => Dark_Red,
+        parenthesis_background          => 16#cbe7f5#,
+        matched_word_highlight          => Dark_Green,
+        messages_foreground             => Black,
+        messages_background             => White,
+        messages_control_background     => White,
+        tool_tip_background             => Very_Light_Gray,
+        tool_tip_foreground_highlighted => Dark_Blue,
+        caret_line_background           => 16#f0f0ff#,
+        bookmark_foreground             => Blue,
+        bookmark_background             => Light_Blue,
+        line_number_background          => Very_Light_Gray),
+
+     Dark_Side =>
+       (foreground                      => Light_Gray,
+        background                      => 16#222324#,
+        keyword                         => Dark_Orange,
+        number                          => Red,
+        comment                         => 16#729fcf#,
+        string_literal                  => Yellow,
+        character_literal               => Yellow,
+        error_foreground                => White,
+        error_background                => Dark_Red,
+        caret                           => White,
+        selection_foreground            => White,
+        selection_background            => 16#2280d2#,
+        matched_parenthesis             => Green,
+        unmatched_parenthesis           => Red,
+        parenthesis_background          => 16#505050#,
+        matched_word_highlight          => Green,
+        messages_foreground             => Light_Gray,
+        messages_background             => 16#161718#,
+        messages_control_background     => 16#121314#,
+        tool_tip_background             => Dark_Gray,
+        tool_tip_foreground_highlighted => Light_Blue,
+        caret_line_background           => 16#402020#,
+        bookmark_foreground             => 16#c06060#,
+        bookmark_background             => 16#c06060#,
+        line_number_background          => 16#383334#),
+
+     Solarized_Light =>
+       (foreground                      => Solarized.base01,
+        background                      => Solarized.base3,
+        keyword                         => Solarized.green,
+        number                          => Solarized.magenta,
+        comment                         => Solarized.base1,
+        string_literal                  => Solarized.cyan,
+        character_literal               => Solarized.blue,
+        error_foreground                => Solarized.base3,
+        error_background                => Solarized.orange,
+        caret                           => Black,
+        selection_foreground            => Solarized.base3,
+        selection_background            => Solarized.base00,
+        matched_parenthesis             => Solarized.green,
+        unmatched_parenthesis           => Solarized.red,
+        parenthesis_background          => Solarized.base2,
+        matched_word_highlight          => Orange,  --  Scintilla blends this with background.
+        messages_foreground             => Solarized.base02,
+        messages_background             => Solarized.base3,
+        messages_control_background     => Solarized.base2,
+        tool_tip_background             => 16#fdf3e0#,  --  base2, a bit darker
+        tool_tip_foreground_highlighted => Dark_Blue,
+        caret_line_background           => 16#ffe8d8#,
+        bookmark_foreground             => 16#ffc8c8#,
+        bookmark_background             => 16#ffc8c8#,
+        line_number_background          => 16#f6ecdc#));
+
+  --  *************************************************************************
   function Nice_Image (ct : Color_Theme_Type) return UTF_16_String is
   begin
     case ct is
@@ -9,6 +138,7 @@ package body LEA_Common.Color_Themes is
     end case;
   end Nice_Image;
 
+  --  *************************************************************************
   function Nice_Value (im : UTF_16_String) return Color_Theme_Type is
   begin
     for ct in Color_Theme_Type loop
@@ -18,5 +148,42 @@ package body LEA_Common.Color_Themes is
     end loop;
     return Default;
   end Nice_Value;
+
+  --  *************************************************************************
+  procedure Select_Theme (Theme : Color_Theme_Type) is
+  begin
+    Selected_Theme := Theme;
+  end Select_Theme;
+
+  --  *************************************************************************
+  function Current_Theme return Color_Theme_Type is
+  begin
+    return Selected_Theme;
+  end Current_Theme;
+
+  --  *************************************************************************
+  function Theme_Color (Topic : Color_Topic) return RGB_Type is
+  begin
+    return theme_color_array (Selected_Theme, Topic);
+  end Theme_Color;
+
+  --  *************************************************************************
+  function Theme_Color (Theme : Color_Theme_Type;
+                        Topic : Color_Topic) return RGB_Type is
+  begin
+    return theme_color_array (Theme, Topic);
+  end Theme_Color;
+
+  --  *************************************************************************
+  function Theme_Dark_Backgrounded return Boolean is
+  begin
+    return Selected_Theme = Dark_Side;
+  end Theme_Dark_Backgrounded;
+
+  --  *************************************************************************
+  function Theme_Dark_Backgrounded (Theme : Color_Theme_Type) return Boolean is
+  begin
+    return Theme = Dark_Side;
+  end Theme_Dark_Backgrounded;
 
 end LEA_Common.Color_Themes;

--- a/lea_common-color_themes.ads
+++ b/lea_common-color_themes.ads
@@ -5,12 +5,6 @@ package LEA_Common.Color_Themes is
 
   type Color_Theme_Type is (Default, Dark_Side, Solarized_Light);
 
-  dark_backgrounded : constant array (Color_Theme_Type) of Boolean :=
-    (Dark_Side => True, others => False);
-
-  function Nice_Image (ct : Color_Theme_Type) return UTF_16_String;
-  function Nice_Value (im : UTF_16_String) return Color_Theme_Type;
-
   type Color_Topic is
     (foreground, background,
      keyword, number, comment,
@@ -38,130 +32,26 @@ package LEA_Common.Color_Themes is
 
   type RGB_Type is range 0 .. 2**24 - 1;
 
-  White           : constant RGB_Type := 16#FFFFFF#;
-  Black           : constant RGB_Type := 16#000000#;
-  Silver          : constant RGB_Type := 16#E0E0E0#;
-  Very_Light_Gray : constant RGB_Type := 16#F8F8F8#;
-  Light_Gray      : constant RGB_Type := 16#C0C0C0#;
-  Gray            : constant RGB_Type := 16#808080#;
-  Dark_Gray       : constant RGB_Type := 16#404040#;
-  Red             : constant RGB_Type := 16#FF0000#;
-  Dark_Red        : constant RGB_Type := 16#800000#;
-  Green           : constant RGB_Type := 16#00FF00#;
-  Dark_Green      : constant RGB_Type := 16#008000#;
-  Light_Blue      : constant RGB_Type := 16#88DDFF#;
-  Blue            : constant RGB_Type := 16#0000FF#;
-  Dark_Blue       : constant RGB_Type := 16#000080#;
-  Yellow          : constant RGB_Type := 16#FFFF00#;
-  Magenta         : constant RGB_Type := 16#FF00FF#;
-  Cyan            : constant RGB_Type := 16#00FFFF#;
-  Pink            : constant RGB_Type := 16#FFAFAF#;
-  Orange          : constant RGB_Type := 16#FFC800#;
-  Dark_Orange     : constant RGB_Type := 16#F08D24#;
+  function Nice_Image (ct : Color_Theme_Type) return UTF_16_String;
+  function Nice_Value (im : UTF_16_String) return Color_Theme_Type;
 
-  package Solarized is
-    --  https://ethanschoonover.com/solarized/#the-values
-    --  https://en.wikipedia.org/wiki/Solarized
+  --  Select the current Theme
+  procedure Select_Theme (Theme : Color_Theme_Type);
 
-    --  Base tones, dark to light:
-    base02 : constant RGB_Type := 16#073642#;
-    base01 : constant RGB_Type := 16#586e75#;
-    base00 : constant RGB_Type := 16#657b83#;
-    base0  : constant RGB_Type := 16#839496#;
-    base1  : constant RGB_Type := 16#93a1a1#;
-    base2  : constant RGB_Type := 16#eee8d5#;
-    base3  : constant RGB_Type := 16#fdf6e3#;
+  --  Return the currently selected Theme
+  function  Current_Theme return Color_Theme_Type;
 
-    --  Colours:
-    orange  : constant RGB_Type := 16#cb4b16#;
-    red     : constant RGB_Type := 16#dc322f#;
-    magenta : constant RGB_Type := 16#d33682#;
-    blue    : constant RGB_Type := 16#268bd2#;
-    cyan    : constant RGB_Type := 16#2aa198#;
-    green   : constant RGB_Type := 16#859900#;
+  --  Return the Topic color of the current Theme
+  function  Theme_Color (Topic : Color_Topic) return RGB_Type;
 
-  end Solarized;
+  --  Return the Topic color of Theme
+  function  Theme_Color (Theme : Color_Theme_Type;
+                         Topic : Color_Topic) return RGB_Type;
 
-  theme_color : constant array (Color_Theme_Type, Color_Topic) of RGB_Type :=
-    (Default =>
-       (foreground                      => 16#101010#,
-        background                      => White,
-        keyword                         => Blue,
-        number                          => Dark_Orange,
-        comment                         => Dark_Green,
-        string_literal                  => Dark_Gray,
-        character_literal               => Dark_Gray,
-        error_foreground                => Black,
-        error_background                => Pink,
-        caret                           => Black,
-        selection_foreground            => Black,
-        selection_background            => Light_Gray,
-        matched_parenthesis             => Dark_Green,
-        unmatched_parenthesis           => Dark_Red,
-        parenthesis_background          => 16#cbe7f5#,
-        matched_word_highlight          => Dark_Green,
-        messages_foreground             => Black,
-        messages_background             => White,
-        messages_control_background     => White,
-        tool_tip_background             => Very_Light_Gray,
-        tool_tip_foreground_highlighted => Dark_Blue,
-        caret_line_background           => 16#f0f0ff#,
-        bookmark_foreground             => Blue,
-        bookmark_background             => Light_Blue,
-        line_number_background          => Very_Light_Gray),
+  --  Return True when the current Theme has a dark background else False
+  function  Theme_Dark_Backgrounded return Boolean;
 
-     Dark_Side =>
-       (foreground                      => Light_Gray,
-        background                      => 16#222324#,
-        keyword                         => Dark_Orange,
-        number                          => Red,
-        comment                         => 16#729fcf#,
-        string_literal                  => Yellow,
-        character_literal               => Yellow,
-        error_foreground                => White,
-        error_background                => Dark_Red,
-        caret                           => White,
-        selection_foreground            => White,
-        selection_background            => 16#2280d2#,
-        matched_parenthesis             => Green,
-        unmatched_parenthesis           => Red,
-        parenthesis_background          => 16#505050#,
-        matched_word_highlight          => Green,
-        messages_foreground             => Light_Gray,
-        messages_background             => 16#161718#,
-        messages_control_background     => 16#121314#,
-        tool_tip_background             => Dark_Gray,
-        tool_tip_foreground_highlighted => Light_Blue,
-        caret_line_background           => 16#402020#,
-        bookmark_foreground             => 16#c06060#,
-        bookmark_background             => 16#c06060#,
-        line_number_background          => 16#383334#),
-
-     Solarized_Light =>
-       (foreground                      => Solarized.base01,
-        background                      => Solarized.base3,
-        keyword                         => Solarized.green,
-        number                          => Solarized.magenta,
-        comment                         => Solarized.base1,
-        string_literal                  => Solarized.cyan,
-        character_literal               => Solarized.blue,
-        error_foreground                => Solarized.base3,
-        error_background                => Solarized.orange,
-        caret                           => Black,
-        selection_foreground            => Solarized.base3,
-        selection_background            => Solarized.base00,
-        matched_parenthesis             => Solarized.green,
-        unmatched_parenthesis           => Solarized.red,
-        parenthesis_background          => Solarized.base2,
-        matched_word_highlight          => Orange,  --  Scintilla blends this with background.
-        messages_foreground             => Solarized.base02,
-        messages_background             => Solarized.base3,
-        messages_control_background     => Solarized.base2,
-        tool_tip_background             => 16#fdf3e0#,  --  base2, a bit darker
-        tool_tip_foreground_highlighted => Dark_Blue,
-        caret_line_background           => 16#ffe8d8#,
-        bookmark_foreground             => 16#ffc8c8#,
-        bookmark_background             => 16#ffc8c8#,
-        line_number_background          => 16#f6ecdc#));
+  --  Return True when Theme has a dark background else False
+  function  Theme_Dark_Backgrounded (Theme : Color_Theme_Type) return Boolean;
 
 end LEA_Common.Color_Themes;

--- a/lea_gwin-editor.adb
+++ b/lea_gwin-editor.adb
@@ -229,7 +229,7 @@ package body LEA_GWin.Editor is
           when others =>
             null;
         end case;
-        Editor.Set_Tip_Styles (main.opt.color_theme);
+        Editor.Set_Tip_Styles;
         Editor.Call_Tip_Show
           (cur_pos,
            GU2G (tip));
@@ -391,7 +391,7 @@ package body LEA_GWin.Editor is
       use Ada.Directories, LEA_Common.Color_Themes;
     begin
       --  Mouse hover tool tip
-      Editor.Set_Tip_Styles (main.opt.color_theme);
+      Editor.Set_Tip_Styles;
       if decl.is_built_in then
         Editor.Call_Tip_Show (Pos, padded_id_name);
       else
@@ -663,27 +663,26 @@ package body LEA_GWin.Editor is
     --
     parent    : MDI_Child_Type renames MDI_Child_Type (Editor.mdi_parent.all);
     mdi_root  : MDI_Main_Type renames parent.mdi_root.all;
-    theme     : Color_Theme_Type renames mdi_root.opt.color_theme;
     Edit_Zone : constant := SCE_ADA_DEFAULT;
   begin
     --  General style
     --  Font color of the line numbers in the left margin:
     Editor.Style_Set_Fore (STYLE_DEFAULT, GWindows.Colors.Gray);
-    Editor.Style_Set_Back (STYLE_DEFAULT, GWindows_Color_Theme (theme, background));
+    Editor.Style_Set_Back (STYLE_DEFAULT, Color_Convert (Theme_Color (background)));
     Editor.Style_Set_Size (STYLE_DEFAULT, App_default_font_size);
     Editor.Style_Set_Font (STYLE_DEFAULT, App_default_font);
-    Editor.Set_Sel_Fore (True, GWindows_Color_Theme (theme, selection_foreground));
-    Editor.Set_Sel_Back (True, GWindows_Color_Theme (theme, selection_background));
+    Editor.Set_Sel_Fore (True, Color_Convert (Theme_Color (selection_foreground)));
+    Editor.Set_Sel_Back (True, Color_Convert (Theme_Color (selection_background)));
     Editor.Style_Clear_All;
     --  Font color of the editor zone (not related to Ada, and works
     --  only *after* Style_Clear_All, for some reason):
-    Editor.Style_Set_Fore (SCE_ADA_DEFAULT, GWindows_Color_Theme (theme, foreground));
-    Editor.Set_Caret_Fore (GWindows_Color_Theme (theme, caret));
-    Editor.Set_Caret_Line_Back (GWindows_Color_Theme (theme, caret_line_background));
-    Editor.Style_Set_Fore (STYLE_LINENUMBER, GWindows_Color_Theme (theme, foreground));
-    Editor.Style_Set_Back (STYLE_LINENUMBER, GWindows_Color_Theme (theme, line_number_background));
-    Editor.Marker_Set_Fore (marker_for_bookmarks, GWindows_Color_Theme (theme, bookmark_foreground));
-    Editor.Marker_Set_Back (marker_for_bookmarks, GWindows_Color_Theme (theme, bookmark_background));
+    Editor.Style_Set_Fore (SCE_ADA_DEFAULT, Color_Convert (Theme_Color (foreground)));
+    Editor.Set_Caret_Fore (Color_Convert (Theme_Color (caret)));
+    Editor.Set_Caret_Line_Back (Color_Convert (Theme_Color (caret_line_background)));
+    Editor.Style_Set_Fore (STYLE_LINENUMBER, Color_Convert (Theme_Color (foreground)));
+    Editor.Style_Set_Back (STYLE_LINENUMBER, Color_Convert (Theme_Color (line_number_background)));
+    Editor.Marker_Set_Fore (marker_for_bookmarks, Color_Convert (Theme_Color (bookmark_foreground)));
+    Editor.Marker_Set_Back (marker_for_bookmarks, Color_Convert (Theme_Color (bookmark_background)));
 
     if Editor.document_kind /= editable_text then
       Editor.Set_Edge_Mode (EDGE_NONE);
@@ -695,37 +694,37 @@ package body LEA_GWin.Editor is
 
     --  Style: parentheses coloring
     --    For matched parentheses:
-    Editor.Style_Set_Fore (STYLE_BRACELIGHT, GWindows_Color_Theme (theme, matched_parenthesis));
-    Editor.Style_Set_Back (STYLE_BRACELIGHT, GWindows_Color_Theme (theme, parenthesis_background));
+    Editor.Style_Set_Fore (STYLE_BRACELIGHT, Color_Convert (Theme_Color (matched_parenthesis)));
+    Editor.Style_Set_Back (STYLE_BRACELIGHT, Color_Convert (Theme_Color (parenthesis_background)));
     --    For unmatched parentheses:
-    Editor.Style_Set_Fore (STYLE_BRACEBAD, GWindows_Color_Theme (theme, unmatched_parenthesis));
-    Editor.Style_Set_Back (STYLE_BRACEBAD, GWindows_Color_Theme (theme, parenthesis_background));
+    Editor.Style_Set_Fore (STYLE_BRACEBAD, Color_Convert (Theme_Color (unmatched_parenthesis)));
+    Editor.Style_Set_Back (STYLE_BRACEBAD, Color_Convert (Theme_Color (parenthesis_background)));
 
     --  Style: Ada-specific coloring
-    Editor.Style_Set_Fore (SCE_ADA_DEFAULT, GWindows_Color_Theme (theme, foreground));
-    Editor.Style_Set_Back (SCE_ADA_DEFAULT, GWindows_Color_Theme (theme, background));
+    Editor.Style_Set_Fore (SCE_ADA_DEFAULT, Color_Convert (Theme_Color (foreground)));
+    Editor.Style_Set_Back (SCE_ADA_DEFAULT, Color_Convert (Theme_Color (background)));
     Editor.Style_Set_Size (SCE_ADA_DEFAULT, App_default_font_size);
     Editor.Style_Set_Font (SCE_ADA_DEFAULT, App_default_font);
     --
-    Editor.Style_Set_Fore (SCE_ADA_COMMENTLINE, GWindows_Color_Theme (theme, comment));
-    Editor.Style_Set_Fore (SCE_ADA_NUMBER,      GWindows_Color_Theme (theme, number));
-    Editor.Style_Set_Fore (SCE_ADA_WORD,        GWindows_Color_Theme (theme, keyword));
-    Editor.Style_Set_Fore (SCE_ADA_STRING,      GWindows_Color_Theme (theme, string_literal));
-    Editor.Style_Set_Fore (SCE_ADA_CHARACTER,   GWindows_Color_Theme (theme, character_literal));
-    Editor.Style_Set_Fore (SCE_ADA_IDENTIFIER,  GWindows_Color_Theme (theme, foreground));
+    Editor.Style_Set_Fore (SCE_ADA_COMMENTLINE, Color_Convert (Theme_Color (comment)));
+    Editor.Style_Set_Fore (SCE_ADA_NUMBER,      Color_Convert (Theme_Color (number)));
+    Editor.Style_Set_Fore (SCE_ADA_WORD,        Color_Convert (Theme_Color (keyword)));
+    Editor.Style_Set_Fore (SCE_ADA_STRING,      Color_Convert (Theme_Color (string_literal)));
+    Editor.Style_Set_Fore (SCE_ADA_CHARACTER,   Color_Convert (Theme_Color (character_literal)));
+    Editor.Style_Set_Fore (SCE_ADA_IDENTIFIER,  Color_Convert (Theme_Color (foreground)));
     --
     --  Cases where the text is obviously wrong
     --  (unfinished character or string, illegal identifier)
-    Editor.Style_Set_Fore (SCE_ADA_CHARACTEREOL, GWindows_Color_Theme (theme, error_foreground));
-    Editor.Style_Set_Back (SCE_ADA_CHARACTEREOL, GWindows_Color_Theme (theme, error_background));
-    Editor.Style_Set_Fore (SCE_ADA_STRINGEOL, GWindows_Color_Theme (theme, error_foreground));
-    Editor.Style_Set_Back (SCE_ADA_STRINGEOL, GWindows_Color_Theme (theme, error_background));
-    Editor.Style_Set_Fore (SCE_ADA_ILLEGAL, GWindows_Color_Theme (theme, error_foreground));
-    Editor.Style_Set_Back (SCE_ADA_ILLEGAL, GWindows_Color_Theme (theme, error_background));
+    Editor.Style_Set_Fore (SCE_ADA_CHARACTEREOL, Color_Convert (Theme_Color (error_foreground)));
+    Editor.Style_Set_Back (SCE_ADA_CHARACTEREOL, Color_Convert (Theme_Color (error_background)));
+    Editor.Style_Set_Fore (SCE_ADA_STRINGEOL, Color_Convert (Theme_Color (error_foreground)));
+    Editor.Style_Set_Back (SCE_ADA_STRINGEOL, Color_Convert (Theme_Color (error_background)));
+    Editor.Style_Set_Fore (SCE_ADA_ILLEGAL, Color_Convert (Theme_Color (error_foreground)));
+    Editor.Style_Set_Back (SCE_ADA_ILLEGAL, Color_Convert (Theme_Color (error_background)));
 
     Editor.Indic_Set_Fore (
       word_highlighting_indicator_index,
-      GWindows_Color_Theme (theme, matched_word_highlight)
+      Color_Convert (Theme_Color (matched_word_highlight))
     );
 
     case mdi_root.opt.show_special is
@@ -1140,18 +1139,16 @@ package body LEA_GWin.Editor is
     end if;
   end Semantics;
 
-  procedure Set_Tip_Styles
-    (Editor : in out LEA_Scintilla_Type;
-     Theme  :        LEA_Common.Color_Themes.Color_Theme_Type)
+  procedure Set_Tip_Styles (Editor : in out LEA_Scintilla_Type)
   is
     use LEA_Common.Color_Themes;
   begin
     Editor.Call_Tip_Set_Background_Color
-      (GWindows_Color_Theme (Theme, tool_tip_background));
+      (Color_Convert (Theme_Color (tool_tip_background)));
     Editor.Call_Tip_Set_Foreground_Color
-      (GWindows_Color_Theme (Theme, foreground));
+      (Color_Convert (Theme_Color (foreground)));
     Editor.Call_Tip_Set_Foreground_Color_Highlighted
-      (GWindows_Color_Theme (Theme, tool_tip_foreground_highlighted));
+      (Color_Convert (Theme_Color (tool_tip_foreground_highlighted)));
   end Set_Tip_Styles;
 
   procedure Bookmark_Next (Editor : in out LEA_Scintilla_Type) is

--- a/lea_gwin-editor.ads
+++ b/lea_gwin-editor.ads
@@ -17,7 +17,7 @@ package LEA_GWin.Editor is
 
   type LEA_Scintilla_Type is new Scintilla_Type with record
     --  Direct access to the window owning the editor widget.
-    --  This is needed to reach the options (color theme, etc.).
+    --  This is needed to reach the options.
     mdi_parent               : GWindows.Base.Pointer_To_Base_Window_Class;
     document_kind            : LEA_Common.Document_kind_type
                                        := LEA_Common.editable_text;
@@ -95,9 +95,7 @@ package LEA_GWin.Editor is
   --  through declarations.
   procedure Semantics (Editor : in out LEA_Scintilla_Type);
 
-  procedure Set_Tip_Styles
-    (Editor : in out LEA_Scintilla_Type;
-     Theme  :        LEA_Common.Color_Themes.Color_Theme_Type);
+  procedure Set_Tip_Styles (Editor : in out LEA_Scintilla_Type);
 
   --  Bookmarks
   procedure Bookmark_Next (Editor : in out LEA_Scintilla_Type);

--- a/lea_gwin-mdi_child.adb
+++ b/lea_gwin-mdi_child.adb
@@ -567,7 +567,7 @@ package body LEA_GWin.MDI_Child is
     procedure LEA_HAC_Build_Error_Feedback (diagnostic : Diagnostic_Kit) is
       use Ada.Characters.Handling, Ada.Strings, Ada.Strings.Wide_Fixed, LEA_Common.Color_Themes;
       msg_up : String := To_String (diagnostic.message);
-      has_dark_background : constant Boolean := dark_backgrounded (MDI_Main.opt.color_theme);
+      has_dark_background : constant Boolean := Theme_Dark_Backgrounded;
     begin
       msg_up (msg_up'First) := To_Upper (msg_up (msg_up'First));
       ml.Insert_Item (

--- a/lea_gwin-messages.adb
+++ b/lea_gwin-messages.adb
@@ -83,12 +83,11 @@ package body LEA_GWin.Messages is
     use GWindows.Colors, LEA_Common, LEA_Common.Color_Themes, MDI_Main;
     --
     mdi_root : MDI_Main_Type renames MDI_Main_Type (Control.mdi_main_parent.all);
-    theme    : Color_Theme_Type renames mdi_root.opt.color_theme;
   begin
-    Control.Text_Color (GWindows_Color_Theme (theme, messages_foreground));
-    Control.Back_Color (GWindows_Color_Theme (theme, messages_background));
-    Control.Control_Back_Color (GWindows_Color_Theme (theme, messages_control_background));
-    mdi_root.Message_Panel.Background_Color (GWindows_Color_Theme (theme, messages_control_background));
+    Control.Text_Color (Color_Convert (Theme_Color (messages_foreground)));
+    Control.Back_Color (Color_Convert (Theme_Color (messages_background)));
+    Control.Control_Back_Color (Color_Convert (Theme_Color (messages_control_background)));
+    mdi_root.Message_Panel.Background_Color (Color_Convert (Theme_Color (messages_control_background)));
   end Apply_Options;
 
   procedure Copy_Messages (Control : in out Message_List_Type) is
@@ -129,8 +128,7 @@ package body LEA_GWin.Messages is
 
   procedure Redraw_Icons (Control : in out Message_List_Type) is
     use HAC_Sys.Defs, LEA_Common.Color_Themes, LEA_LV_Ex;
-    has_dark_background : constant Boolean :=
-      dark_backgrounded (MDI_Main.MDI_Main_Type (Control.mdi_main_parent.all).opt.color_theme);
+    has_dark_background : constant Boolean := Theme_Dark_Backgrounded;
   begin
     for i in 0 .. Control.Item_Count - 1 loop
       if Control.Item_Data (i) /= null

--- a/lea_gwin-options.adb
+++ b/lea_gwin-options.adb
@@ -91,8 +91,9 @@ package body LEA_GWin.Options is
         MDI_Child_Type (Window.all).Editor.Apply_Options;
       end if;
     end Apply_changes_to_child;
-    use LEA_GWin.MDI_Main;
+    use LEA_GWin.MDI_Main, LEA_Common.Color_Themes;
   begin
+    Select_Theme (main.opt.color_theme);
     main.text_files_filters (main.text_files_filters'First).Filter := main.opt.ada_files_filter;
     main.Message_Panel.Message_List.Apply_Options;
     main.Message_Panel.Redraw;

--- a/lea_gwin.adb
+++ b/lea_gwin.adb
@@ -50,12 +50,12 @@ package body LEA_GWin is
          Blue  => Color_Range (rgb mod (2**8)));
   end Color_Convert;
 
-  function GWindows_Color_Theme
-    (theme : LEA_Common.Color_Themes.Color_Theme_Type;
-     topic : LEA_Common.Color_Themes.Color_Topic) return GWindows.Colors.Color_Type
-  is
-  begin
-    return Color_Convert (LEA_Common.Color_Themes.theme_color (theme, topic));
-  end GWindows_Color_Theme;
+--   function GWindows_Color_Theme
+--     (theme : LEA_Common.Color_Themes.Color_Theme_Type;
+--      topic : LEA_Common.Color_Themes.Color_Topic) return GWindows.Colors.Color_Type
+--   is
+--   begin
+--     return Color_Convert (LEA_Common.Color_Themes.theme_color (theme, topic));
+--   end GWindows_Color_Theme;
 
 end LEA_GWin;

--- a/lea_gwin.ads
+++ b/lea_gwin.ads
@@ -41,9 +41,9 @@ package LEA_GWin is
   function Color_Convert
     (rgb : LEA_Common.Color_Themes.RGB_Type) return GWindows.Colors.Color_Type;
 
-  function GWindows_Color_Theme
-    (theme : LEA_Common.Color_Themes.Color_Theme_Type;
-     topic : LEA_Common.Color_Themes.Color_Topic) return GWindows.Colors.Color_Type;
+--   function GWindows_Color_Theme
+--     (theme : LEA_Common.Color_Themes.Color_Theme_Type;
+--      topic : LEA_Common.Color_Themes.Color_Topic) return GWindows.Colors.Color_Type;
 
   bool_to_state : constant array (Boolean) of GWindows.Menus.State_Type :=
     (GWindows.Menus.Disabled, GWindows.Menus.Enabled);


### PR DESCRIPTION
Modify Theme color management.
Move some content from `LEA_Common.Color_Themes` specification to body. 
Add functions to `LEA_Common.Color_Themes` package to manage Theme colors.
Replace main window `opt.color_theme` accesses from child windows with `LEA_Common.Color_Themes` package functions.