### PR TITLE
Make options global.

### DIFF
--- a/lea_common-user_options.ads
+++ b/lea_common-user_options.ads
@@ -55,6 +55,9 @@ package LEA_Common.User_options is
     smart_editor : Boolean := True;
   end record;
 
+  --  Global options
+  Options : LEA_Common.User_options.Option_Pack_Type;
+
   procedure Toggle_show_special (o : in out Option_Pack_Type);
 
   -----------------

--- a/lea_gwin-editor.adb
+++ b/lea_gwin-editor.adb
@@ -32,6 +32,8 @@ package body LEA_GWin.Editor is
   use Ada.Strings, Ada.Strings.Wide_Fixed;
   use GWindows.Message_Boxes;
 
+  Options : LEA_Common.User_options.Option_Pack_Type renames LEA_Common.User_options.Options;
+
   overriding procedure On_Change (Editor : in out LEA_Scintilla_Type) is
     --  parent: MDI_Child_Type renames MDI_Child_Type(Editor.MDI_Root.all);
   begin
@@ -109,7 +111,7 @@ package body LEA_GWin.Editor is
       then
         --  On a "Return" keypress right after "begin", "record" or "(",
         --  we add an extra indentation.
-        new_ind := new_ind + MDI_Child_Type (Editor.mdi_parent.all).mdi_root.opt.indentation;
+        new_ind := new_ind + Options.indentation;
       end if;
       --
       --  Now, add the bonus keystrokes. We merge all keystrokes (the
@@ -238,7 +240,7 @@ package body LEA_GWin.Editor is
     begin
       for pos in reverse Position'Max (0, cur_pos - search_tolerance) .. cur_pos loop
         if Editor.Get_Style_At (pos) = SCE_ADA_IDENTIFIER then
-          case main.opt.toolset is
+          case Options.toolset is
             when HAC_mode =>
               Editor.Find_HAC_Declarations (pos, decl_1, decl_2, found);
               if found > 0 then
@@ -289,8 +291,6 @@ package body LEA_GWin.Editor is
       end if;
     end Try_Auto_Complete;
 
-    opt : LEA_Common.User_options.Option_Pack_Type
-            renames MDI_Child_Type (Editor.mdi_parent.all).mdi_root.opt;
   begin
     if Editor.Get_Selections > 1 then
       --  Auto-insertion of any kind is disabled when there are multiple
@@ -306,21 +306,21 @@ package body LEA_GWin.Editor is
           Process_Return_Keystroke;
         end if;
       when '(' | '"' =>
-        if opt.auto_insert then
+        if Options.auto_insert then
           Try_Auto_Insert;
         end if;
-        if Value = '(' and then opt.smart_editor then
+        if Value = '(' and then Options.smart_editor then
           --  Consider a Call Tip (showing parameters of a subprogram).
           Try_Call_Tip;
         end if;
       when ')' =>
         Editor.Call_Tip_Cancel;
       when 'A' .. 'Z' | 'a' .. 'z' | '_'  | '0' .. '9' =>
-        if opt.smart_editor then
+        if Options.smart_editor then
           Try_Auto_Complete (dot => False);
         end if;
       when '.' =>
-        if opt.smart_editor then
+        if Options.smart_editor then
           Try_Auto_Complete (dot => True);
         end if;
       when others =>
@@ -408,8 +408,8 @@ package body LEA_GWin.Editor is
     --
     found : Natural;
   begin
-    if main.opt.smart_editor then
-      case main.opt.toolset is
+    if Options.smart_editor then
+      case Options.toolset is
         when HAC_mode =>
           Editor.Find_HAC_Declarations (Pos, decl_1, decl_2, found);
           if found > 0 then
@@ -689,8 +689,8 @@ package body LEA_GWin.Editor is
       return;
     end if;
 
-    Editor.Set_Tab_Width (mdi_root.opt.tab_width);
-    Editor.Set_Edge_Column (mdi_root.opt.right_margin);
+    Editor.Set_Tab_Width (Options.tab_width);
+    Editor.Set_Edge_Column (Options.right_margin);
 
     --  Style: parentheses coloring
     --    For matched parentheses:
@@ -727,7 +727,7 @@ package body LEA_GWin.Editor is
       Color_Convert (Theme_Color (matched_word_highlight))
     );
 
-    case mdi_root.opt.show_special is
+    case Options.show_special is
       when none =>
         Editor.Set_View_WS (SCWS_INVISIBLE);
         Editor.Set_View_EOL (False);
@@ -738,7 +738,7 @@ package body LEA_GWin.Editor is
         Editor.Set_View_WS (SCWS_VISIBLEALWAYS);
         Editor.Set_View_EOL (True);
     end case;
-    Editor.Set_Indentation_Guides (mdi_root.opt.show_indent);
+    Editor.Set_Indentation_Guides (Options.show_indent);
   end Apply_Options;
 
   procedure Set_Current_Line (Editor : in out LEA_Scintilla_Type; line : Integer) is
@@ -1117,7 +1117,7 @@ package body LEA_GWin.Editor is
     --
     trace_enabled : constant Boolean := False;
   begin
-    if main.opt.smart_editor then
+    if Options.smart_editor then
       main.BD_sem.Set_Target
         (HAC_Sys.Targets.Abstract_Machine_Reference (main.sem_machine));
       HAC_Sys.Targets.Semantics.Machine (main.sem_machine.all).CD := main.BD_sem.CD;

--- a/lea_gwin-mdi_main.ads
+++ b/lea_gwin-mdi_main.ads
@@ -58,8 +58,7 @@ package LEA_GWin.MDI_Main is
         User_maximize_restore       : Boolean := True;
         --  ^ Detect user-triggered max/restore commands
         record_dimensions           : Boolean := False; -- in On_Move, On_Size
-        --  Options of a "model" child window.
-        opt                         : LEA_Common.User_options.Option_Pack_Type;
+
         --
         Task_bar_gadget_ok          : Boolean := False;  --  Coloring of taskbar icon (Windows 7+)
         Task_bar_gadget             : GWindows.Taskbar.Taskbar_List;

--- a/lea_gwin-options.adb
+++ b/lea_gwin-options.adb
@@ -14,11 +14,13 @@ with GWin_Util;
 
 package body LEA_GWin.Options is
 
+  Options : LEA_Common.User_options.Option_Pack_Type renames LEA_Common.User_options.Options;
+
   procedure On_General_Options (main : in out LEA_GWin.MDI_Main.MDI_Main_Type) is
     use LEA_Resource_GUI, LEA_Common, LEA_Common.Color_Themes, LEA_Common.User_options;
     --
     box : Option_box_Type;
-    candidate : Option_Pack_Type := main.opt;
+    candidate : Option_Pack_Type := Options;
     --
     procedure Set_Data is
       use GWin_Util;
@@ -70,10 +72,10 @@ package body LEA_GWin.Options is
     On_Destroy_Handler (box, Get_Data'Unrestricted_Access);
     case GWindows.Application.Show_Dialog (box, main) is
       when GWindows.Constants.IDOK =>
-        has_changes := main.opt /= candidate;
+        has_changes := Options /= candidate;
         if has_changes then
-          icons_redrawing := main.opt.color_theme /= candidate.color_theme;
-          main.opt := candidate;
+          icons_redrawing := Options.color_theme /= candidate.color_theme;
+          Options := candidate;
           Apply_Main_Options (main);
           if icons_redrawing then
             main.Message_Panel.Message_List.Redraw_Icons;
@@ -97,8 +99,8 @@ package body LEA_GWin.Options is
     --
     use LEA_GWin.MDI_Main, LEA_Common.Color_Themes;
   begin
-    Select_Theme (main.opt.color_theme);
-    main.text_files_filters (main.text_files_filters'First).Filter := main.opt.ada_files_filter;
+    Select_Theme (Options.color_theme);
+    main.text_files_filters (main.text_files_filters'First).Filter := Options.ada_files_filter;
     main.Project_Panel.Apply_Options;
     main.Message_Panel.Apply_Options;
     main.Update_Common_Menus;

--- a/lea_gwin-repair.adb
+++ b/lea_gwin-repair.adb
@@ -1,3 +1,5 @@
+with LEA_Common.User_options;
+
 with LEA_GWin.MDI_Child;
 
 with HAC_Sys.Errors;
@@ -11,6 +13,8 @@ with Ada.Strings.Unbounded,
      Ada.Strings.Wide_Unbounded;
 
 package body LEA_GWin.Repair is
+
+  Options : LEA_Common.User_options.Option_Pack_Type renames LEA_Common.User_options.Options;
 
   procedure Do_Repair (
     MDI_Main : in out LEA_GWin.MDI_Main.MDI_Main_Type;
@@ -44,7 +48,7 @@ package body LEA_GWin.Repair is
               case c is
                 when 't' =>  --  Tab (\t), replaced by spaces matching indentation setting.
                   if prev_is_backslash then
-                    expanded := expanded & (MDI_Main.opt.indentation) * ' ';
+                    expanded := expanded & (Options.indentation) * ' ';
                   else
                     expanded := expanded & c;
                   end if;

--- a/lea_gwin-run_windowed.adb
+++ b/lea_gwin-run_windowed.adb
@@ -1,4 +1,5 @@
-with LEA_Common;
+with LEA_Common,
+     LEA_Common.User_options;
 
 with LEA_GWin.MDI_Main;
 with LEA_GWin.Messages.IO_Pipe;
@@ -25,7 +26,8 @@ procedure LEA_GWin.Run_Windowed (Window : in out MDI_Child.MDI_Child_Type) is
 
   use Ada.Strings.Unbounded, HAC_Sys.PCode.Interpreter, LEA_Common, GWindows.Message_Boxes;
 
-  main : LEA_GWin.MDI_Main.MDI_Main_Type renames Window.mdi_root.all;
+  main    : LEA_GWin.MDI_Main.MDI_Main_Type renames Window.mdi_root.all;
+  Options : LEA_Common.User_options.Option_Pack_Type renames LEA_Common.User_options.Options;
 
   procedure HAC_VM_Interpret is
 
@@ -230,7 +232,7 @@ procedure LEA_GWin.Run_Windowed (Window : in out MDI_Child.MDI_Child_Type) is
 
 begin
   LEA_GWin.Messages.IO_Pipe.is_aborted_flag := False;
-  case Window.mdi_root.opt.toolset is
+  case Options.toolset is
     when HAC_mode =>
       --  !!  Check if anything compiled ?
       if Window.mdi_root.BD.CD.Is_Executable then

--- a/lea_without_data.adb
+++ b/lea_without_data.adb
@@ -9,8 +9,12 @@ with GWindows.Application,
      GWindows.Single_Instance,
      GWindows.Types;
 
+with LEA_Common.User_options,
+     LEA_Common.Color_Themes;
+
 with LEA_GWin.MDI_Main,
-     LEA_GWin.Installer;
+     LEA_GWin.Installer,
+     LEA_GWin.Persistence;
 
 with Ada.Command_Line,
      Ada.Exceptions;
@@ -18,6 +22,8 @@ with Ada.Command_Line,
 with GNAT.Traceback.Symbolic;
 
 procedure LEA_Without_Data is
+
+  Options : LEA_Common.User_options.Option_Pack_Type renames LEA_Common.User_options.Options;
 
   Top : LEA_GWin.MDI_Main.MDI_Main_Type;
 
@@ -58,6 +64,9 @@ procedure LEA_Without_Data is
   begin
     GWindows.Base.On_Exception_Handler (Handler => Interactive_crash'Unrestricted_Access);
 
+    LEA_GWin.Persistence.Blockwise_IO.Load (Options);
+    LEA_Common.Color_Themes.Select_Theme (Options.color_theme);
+
     LEA_Single_Instance.Manage_Single_Instance
       (Application_Class_Name    => LEA_Class_Name,
        Application_Instance_Name => LEA_Instance_Name,
@@ -69,6 +78,9 @@ procedure LEA_Without_Data is
       Top.Focus;
       GWindows.Application.Message_Loop;
     end if;
+
+    LEA_GWin.Persistence.Blockwise_IO.Save (Options);
+
   end LEA_start;
 
 begin


### PR DESCRIPTION
The variable containing options is moved to the `LEA_Common.User_options` package.
This makes the access to options much easier (no need to find the MDI main window).
The initialization, loading and saving (persistence) of the options is moved in the `LEA_Without_Data` procedure.
This is useful when options are needed before the MDI main Window initializes the options.
For example, this could let us use an option for mono/multi instance(s) of LEA.
This is necessary for some control colorization (currently the color theme is not known when the toolbar is initialized).