### PR TITLE
Toolbar Colorization.

### DIFF
--- a/lea_gwin-options.adb
+++ b/lea_gwin-options.adb
@@ -1,6 +1,7 @@
 with LEA_Common.User_options;
 
-with LEA_GWin.MDI_Child;
+with LEA_GWin.MDI_Child,
+     LEA_GWin.Toolbars;
 
 with LEA_Resource_GUI;
 
@@ -104,6 +105,7 @@ package body LEA_GWin.Options is
     main.Project_Panel.Apply_Options;
     main.Message_Panel.Apply_Options;
     main.Update_Common_Menus;
+    LEA_GWin.Toolbars.Update_Theme (main.Tool_Bar);
     MDI_Client_Window (main).Enumerate_Children (Apply_Changes_to_Child'Unrestricted_Access);
   end Apply_Main_Options;
 

--- a/lea_gwin-toolbars.adb
+++ b/lea_gwin-toolbars.adb
@@ -1,7 +1,9 @@
-with LEA_Resource_GUI;
+with LEA_Resource_GUI,
+     LEA_Common.Color_Themes;
 
 with GWindows.Base,
-     GWindows.Menus;
+     GWindows.Menus,
+     GWindows.Colors;
 
 with GWin_Util;
 
@@ -14,6 +16,7 @@ package body LEA_GWin.Toolbars is
      parent : in out LEA_GWin.MDI_Main.MDI_Main_Type)
   is
     use LEA_Resource_GUI;
+    use LEA_Common.Color_Themes;
     sep_width : constant := 8;
     Fake_Menu : Menu_MDI_Child_Type;
     --
@@ -75,6 +78,17 @@ package body LEA_GWin.Toolbars is
     tb.Add_Separator (sep_width);
     Add_Button_with_Tip (12, IDM_Show_special_symbols);
     Add_Button_with_Tip (16, IDM_Show_indentation_lines);
+    tb.Background_Color (Color_Convert (Theme_Color (background)));
   end Init_Main_Tool_Bar;
+
+  procedure Update_Theme
+    (tb : in out Office_Applications.Classic_Main_Tool_Bar_Type'Class)
+  is
+    use LEA_Common.Color_Themes;
+  begin
+    tb.Background_Color (Color_Convert (Theme_Color (background)));
+    tb.Redraw (Erase      => True,
+               Redraw_Now => True);
+  end Update_Theme;
 
 end LEA_GWin.Toolbars;

--- a/lea_gwin-toolbars.ads
+++ b/lea_gwin-toolbars.ads
@@ -13,4 +13,7 @@ package LEA_GWin.Toolbars is
     (tb     : in out Office_Applications.Classic_Main_Tool_Bar_Type'Class;
      parent : in out LEA_GWin.MDI_Main.MDI_Main_Type);
 
+  procedure Update_Theme
+    (tb : in out Office_Applications.Classic_Main_Tool_Bar_Type'Class);
+
 end LEA_GWin.Toolbars;


### PR DESCRIPTION
Add Toolbar background colorization.
No new color has been added to the theme. The `background` color is used. Of course, this can be changed.